### PR TITLE
Bugfixes

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,6 @@
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.10" />
-        <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -43,4 +43,20 @@
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
 </project>

--- a/app/src/main/java/tcss450/uw/edu/team12/MyStopsRecyclerViewAdapter.java
+++ b/app/src/main/java/tcss450/uw/edu/team12/MyStopsRecyclerViewAdapter.java
@@ -65,7 +65,7 @@ public class MyStopsRecyclerViewAdapter extends RecyclerView.Adapter<MyStopsRecy
     }
 
     /**
-     * Sets the ViewHolder element with Stop information such as ID and
+     * Sets the RoutesViewHolder element with Stop information such as ID and
      * destination information.
      */
     public class ViewHolder extends RecyclerView.ViewHolder implements RecyclerView.OnClickListener,

--- a/app/src/main/java/tcss450/uw/edu/team12/model/Route.java
+++ b/app/src/main/java/tcss450/uw/edu/team12/model/Route.java
@@ -19,11 +19,13 @@ public class Route implements Serializable {
     public static final String DEPARTURE_TIME = "departure_time";
     public static final String TRIP_HEADSIGN = "trip_headsign";
     public static final String MINUTES = "minutes";
+    public static final String STOP_NAME = "stop_name";
 
     String mRouteName;
     String mDepartureTime;
     String mTripHeadSign;
     String mMinutes;
+    String mStopName;
 
     /**
      * Constructs a route with the name, departure time, headsign, and minutes until arrival.
@@ -33,11 +35,12 @@ public class Route implements Serializable {
      * @param tripHeadSign head sign of the route.
      * @param minutes minutes until the route arrives.
      */
-    public Route(String routeName, String departureTime, String tripHeadSign, String minutes) {
+    public Route(String routeName, String departureTime, String tripHeadSign, String minutes, String stopName) {
         mRouteName = routeName;
         mDepartureTime = departureTime;
         mTripHeadSign = tripHeadSign;
         mMinutes = minutes;
+        mStopName = stopName;
     }
 
     /**
@@ -67,6 +70,8 @@ public class Route implements Serializable {
         return mMinutes;
     }
 
+    public String getStopName() { return mStopName; }
+
     /**
      * Getter for the head sign of the route.
      *
@@ -89,7 +94,7 @@ public class Route implements Serializable {
                 for (int i = 0; i < arr.length(); i++) {
                     JSONObject obj = arr.getJSONObject(i);
                     Route route = new Route(obj.getString(Route.ROUTE_NAME), obj.getString(Route.DEPARTURE_TIME)
-                            ,obj.getString(Route.TRIP_HEADSIGN), obj.getString(Route.MINUTES));
+                            ,obj.getString(Route.TRIP_HEADSIGN), obj.getString(Route.MINUTES), obj.getString(Route.STOP_NAME));
                     routesList.add(route);
                 }
             } catch (JSONException e) {

--- a/app/src/main/res/layout/fragment_route.xml
+++ b/app/src/main/res/layout/fragment_route.xml
@@ -3,7 +3,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
-
     <ImageView
         android:id="@+id/route_context_menu"
         android:layout_width="match_parent"
@@ -32,5 +31,4 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/text_margin"
         android:textAppearance="?attr/textAppearanceListItem" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_route_list.xml
+++ b/app/src/main/res/layout/fragment_route_list.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/swipeContainer"
     android:layout_width="match_parent"
+
     android:layout_height="match_parent">
     <android.support.v7.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -11,6 +12,7 @@
         android:name="tcss450.uw.edu.team12.StopRoutesDetailListFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginTop="80dp"
         android:layout_marginLeft="2dp"
         android:layout_marginRight="2dp"
         app:layoutManager="LinearLayoutManager"

--- a/app/src/main/res/layout/fragment_stop.xml
+++ b/app/src/main/res/layout/fragment_stop.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:src="@drawable/ic_dots_vertical_black_18dp"
-        android:layout_marginRight="16dp"
         />
 
     <TextView

--- a/app/src/main/res/layout/head_layout.xml
+++ b/app/src/main/res/layout/head_layout.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal" android:layout_width="match_parent"
-    android:layout_height="70dp"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="30dp"
     android:background="@color/colorPrimary">
     <TextView
         android:layout_height="match_parent"
@@ -11,7 +12,7 @@
         android:textSize="22dp"
         android:textStyle="bold"
         android:gravity="center"
-        android:id="@+id/stop_name"
+        android:id="@+id/stop_name_header"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/head_layout.xml
+++ b/app/src/main/res/layout/head_layout.xml
@@ -2,14 +2,13 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="30dp"
+    android:layout_height="26dp"
     android:background="@color/colorPrimary">
     <TextView
         android:layout_height="match_parent"
         android:layout_width="match_parent"
-        android:text="Bus stop name"
         android:textColor="#ffffff"
-        android:textSize="22dp"
+        android:textSize="18sp"
         android:textStyle="bold"
         android:gravity="center"
         android:id="@+id/stop_name_header"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <resources>
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="activity_horizontal_margin">4dp</dimen>
+    <dimen name="activity_vertical_margin">4dp</dimen>
     <dimen name="text_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
Stop name header no longer causes the missing of the first item from the db.
Searching for a bus stop id no longer returns an empty stop name for the recycler view header

New feature added - pull to refresh.

It uses SwipeRefreshLayout and is used to update bus arrivals at a given stop.

Content sharing feature implemented. Departure information of selected route can be shared with others.
Fixed issue that prevented from viewing favorites and transit alerts after searching for a bus stop.

Transit alerts feature implemented.

User can see a list of transit alerts for King County Metro that comes from an RSS feed. The list contains a title, as well as a
link that can be followed in order to get detailed information on the selected alert.

'View favorite stops' feature implemented.

Favorite stops can be viewed by tapping on the 'Favorite stops' menu item. The user can also remove a given stop from their
list of favorites by tapping on the three dots (next to the stop id). The RecyclerViewAdapter gets notified of the dataset changes
that were made, so once the stop has been deleted, the change gets reflected instantly.

'Add to favorites' feature implemented.

If stop does not exist in the db file (favorite stops) on the device, then it gets added. Otherwise, the user gets notified that
the stop already exists.

Added context menu for each bus stop recycler view item for the 'add to favorites' functionality.

The "three-dot" overflow pattern was used as icon. Adding a bus stop to favorites needs to be programmed.
